### PR TITLE
Implement #2: Add operation to reclaim all nodes intersecting with a disk

### DIFF
--- a/Sources/DynamicLODTree/DynamicQuadTreeHighLevelExtension.swift
+++ b/Sources/DynamicLODTree/DynamicQuadTreeHighLevelExtension.swift
@@ -100,6 +100,33 @@ public extension DynamicLODTree {
     return modified
   }
   
+  /// Reclaims all nodes that intersects the given disk
+  ///
+  /// - Parameter disk: `(origin: Position, radius: Scalar)` disk defined by origin
+  ///  and radius.
+  /// - Returns: `true` iff any node was reclaimed.
+  /// - Postcondition: For any node `n` with `n.intersects(disk) == true` =>
+  /// `n.isVolatile == false`
+  func reclaim(intersecting disk: (origin: Position, radius: Scalar)) -> Bool {
+    var modified = false
+    
+    guard rootNode.intersects(disk) else {
+      // If the root node does not intersect the disk, no nodes does.
+      return false
+    }
+    
+    var node: NodeType? = rootNode.nextIntersecting(disk)
+    while let n = node {
+      if n.isVolatile {
+        n.reclaimNonRecursive()
+        modified = true
+      }
+      node = n.nextIntersecting(disk)
+    }
+    
+    return modified
+  }
+  
   func fit(to circle: (origin: Position, radius: Scalar)) -> Bool {
     // Ensure the circle is contained in the tree
     let grown = grow(toContainCircle: circle)

--- a/Sources/DynamicLODTree/DynamicQuadTreeHighLevelExtension.swift
+++ b/Sources/DynamicLODTree/DynamicQuadTreeHighLevelExtension.swift
@@ -40,6 +40,18 @@ public extension DynamicLODTree {
     assert(rootNode.contains(point: point))
   }
   
+  /// Grows the tree so that it covers the complete region bound by the given circle
+  ///
+  /// The growing is performed so, that no node in the current tree is modfied. Only the root node will becime
+  /// a child node. If the circle is already contained in the tree, this operations does nothing and returns
+  /// `false`.
+  ///
+  /// - Parameter circle: `(origin: Porisiont, radius: Scalar)` circle defined by origin
+  ///   and radius.
+  /// - Returns: `true` iff the tree was altered.
+  /// - Postcondition: If the tree conainted `circle` nothing is changed, otherwise
+  ///  for any point `p` inside `circle`: `tree.contains(point: p) == true` and the original
+  ///  branch is completely unchanged.
   func grow(toContainCircle circle: (origin: Position, radius: Scalar)) -> Bool {
     let points = [
       circle.origin &+ Position(circle.radius, 0),

--- a/Sources/DynamicLODTree/GeometricQueriesNodeExtension.swift
+++ b/Sources/DynamicLODTree/GeometricQueriesNodeExtension.swift
@@ -1,0 +1,80 @@
+//
+//  GeometricQueriesNodeExtension.swift
+//
+// Copyright (c) 2019, Stefan Reinhold
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+// ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+public extension Node {
+  /// Computes the squared distance from the square region of the node to the given point
+  ///
+  /// The returned squared distance is the squared euclidean distance between `point` and the nearest
+  /// point on the border of the bounding rectangle of the node. If `point` lies inside the node's rect, the
+  /// squared distance is zero.
+  ///
+  /// - Parameter point: point to compute the squared distance to
+  /// - Returns: Squared euclidean distance between `point` and the closest point inside the node's
+  ///     region or zero if `point` lies insde the region.
+  func squaredDistance(to point: PositionType) -> Scalar {
+    let maxPoint = origin &+ size
+    let nearestPoint = point.clamped(lowerBound: origin, upperBound: maxPoint)
+    let delta = point &- nearestPoint
+    let squaredLength = PositionType.dot(delta, delta)
+    
+    return squaredLength
+  }
+  
+  /// Tests if the node region intersects with the given disk.
+  ///
+  /// More formally: the function tests if the intersection of`self`and `disk` is non-empty.
+  ///
+  /// - Parameter disk: `(origin: PositionType, radius:Scalar)`, disk with origin and radius
+  /// - Returns: `true` iff the node's area and the disk intersect.
+  func intersects(_ disk: (origin: PositionType, radius: Scalar)) -> Bool {
+    let dist = squaredDistance(to: disk.origin)
+    
+    return dist <= (disk.radius * disk.radius)
+  }
+  
+  /// Tests if the node's area lies completly inside the given disk
+  ///
+  /// More formally: the function tests if `self` is a  subset of `disk`
+  ///
+  /// - Parameter disk: `(origin: PositionType, radius:Scalar)`, disk with origin and radius
+  /// - Returns: `true` iff the node's area in completely included in `disk`
+  func isIncluded(in disk: (origin: PositionType, radius: Scalar)) -> Bool {
+    let queryPoints = [
+      origin,
+      origin &+ PositionType(size, 0),
+      origin &+ PositionType(0, size),
+      origin &+ size
+    ]
+    
+    let rSq = disk.radius * disk.radius
+    
+    return queryPoints.allSatisfy { q in
+      let delta = disk.origin &- q
+      let distSq = PositionType.dot(delta, delta)
+      return distSq <= rSq
+    }
+  }
+}

--- a/Sources/DynamicLODTree/Node.swift
+++ b/Sources/DynamicLODTree/Node.swift
@@ -169,12 +169,13 @@ public final class Node<Content, PositionType: IntegerPosition2D> {
     assert(isLeaf)
   }
   
-  /// Marks a volatile node as non-volatile
+  /// Marks a branch as non-volatile
   ///
   /// Has no effect on non-volatile nodes.
   /// If called on a non-leaf node it reclaims the complete branch. If the parent node is mark as volatile,
   /// it will be reclaimed, too.
-  /// - Postcondition:self.isVolatile == false
+  /// - Postcondition:`self.isVolatile == false` and for all nodes `n` inside the current branch
+  ///   below the current depth: `n.isVolatile == false`.
   public func reclaim() {
     guard isVolatile else { return }
     isVolatile = false

--- a/Sources/DynamicLODTree/Node.swift
+++ b/Sources/DynamicLODTree/Node.swift
@@ -186,6 +186,20 @@ public final class Node<Content, PositionType: IntegerPosition2D> {
     parent?.reclaim()
   }
   
+  /// Marks a single node as non-volatile
+  ///
+  /// Has no effect on non-volatile nodes.
+  /// Does not reclaim any child nodes.
+  /// Reclaims the parent node
+  /// - Postcondition:self.isVolatile == false
+  public func reclaimNonRecursive() {
+    guard isVolatile else { return }
+    isVolatile = false
+
+    // reclaim parent
+    parent?.reclaim()
+  }
+  
   /// Removes the node and its sub nodes from the tree
   ///
   /// The node is not directly removed from the tree, but marked as volatile instead.

--- a/Sources/DynamicLODTree/NodeIteratorExtension.swift
+++ b/Sources/DynamicLODTree/NodeIteratorExtension.swift
@@ -64,6 +64,29 @@ extension Node {
     return node
   }
   
+  /// Returns the next branch in the tree or nil if the current branch is the last one
+  public func nextBranch() -> Node? {
+    guard !isRoot else { return nil }
+    
+    var parent = self
+    var pos: NormalizedNodePosition = .bottomLeft
+    
+    // if last child of parent, walk up the tree until another child is available
+    while parent.parent != nil {
+      parent = parent.parent!
+      pos = parent.toNormalized(position: origin)
+      if !pos.isLast {
+        break
+      }
+    }
+    
+    if pos.isLast { return nil }
+    
+    let node = parent.children![pos.next]
+    
+    return node
+  }
+  
   public func nextNotIntersecting(_ disk: (origin: PositionType, radius: Scalar)) -> Node? {
     var node = next()
     while let n = node {

--- a/Sources/DynamicLODTree/NodeIteratorExtension.swift
+++ b/Sources/DynamicLODTree/NodeIteratorExtension.swift
@@ -95,7 +95,7 @@ extension Node {
         return n
       } else if n.isIncluded(in: disk) {
         // node is completly included in circle, can skip to next neighbor
-        node = n.nextNeighbor
+        node = n.nextBranch()
       } else {
         // the node and the disk intersects but node is no subset of disk,
         // therefore, there might be a child that does not intersect with disk
@@ -103,6 +103,9 @@ extension Node {
       }
     }
     
+    // If no node was found until here, there is no node left
+    return nil
+  }
     // If no node was found until here, there is no node left
     return nil
   }

--- a/Sources/DynamicLODTree/NodeIteratorExtension.swift
+++ b/Sources/DynamicLODTree/NodeIteratorExtension.swift
@@ -106,6 +106,24 @@ extension Node {
     // If no node was found until here, there is no node left
     return nil
   }
+  
+  /// Returns the next node that intersects the given disk or nil if there are no more intersecrting nodes
+  ///
+  /// - Parameter disk: `(origin: PositionType, radius: Scalar)` disk to check for
+  ///  intersection with
+  /// - Postcondition: `let n = nextIntersecting(disk)` then
+  /// `n.intersects(disk) == true`
+  public func nextIntersecting(_ disk: (origin: PositionType, radius: Scalar)) -> Node? {
+    var node = next()
+    while let n = node {
+      if n.intersects(disk) {
+        return n
+      } else {
+        // if n does not intersect disk, none of the children of n intersects
+        node = n.nextBranch()
+      }
+    }
+    
     // If no node was found until here, there is no node left
     return nil
   }

--- a/Sources/DynamicLODTree/NodeIteratorExtension.swift
+++ b/Sources/DynamicLODTree/NodeIteratorExtension.swift
@@ -63,6 +63,26 @@ extension Node {
     while !(node?.isLeaf ?? true) { node = node?.next() }
     return node
   }
+  
+  public func nextNotIntersecting(_ disk: (origin: PositionType, radius: Scalar)) -> Node? {
+    var node = next()
+    while let n = node {
+      if !n.intersects(disk) {
+        // Found non intersecting node
+        return n
+      } else if n.isIncluded(in: disk) {
+        // node is completly included in circle, can skip to next neighbor
+        node = n.nextNeighbor
+      } else {
+        // the node and the disk intersects but node is no subset of disk,
+        // therefore, there might be a child that does not intersect with disk
+        node = n.next()
+      }
+    }
+    
+    // If no node was found until here, there is no node left
+    return nil
+  }
 }
 
 public struct NodeIterator<Content, Position: IntegerPosition2D>: IteratorProtocol {

--- a/Tests/DynamicLODTreeTests/DynamicLODTreeTests.swift
+++ b/Tests/DynamicLODTreeTests/DynamicLODTreeTests.swift
@@ -424,15 +424,15 @@ class DynamicLODTreeTests: XCTestCase {
     tree.rootNode.subdivide()
     tree.rootNode.children!.forEach { $0.subdivide() }
     
-    let disk = (origin: Position.zero, radius: Int32(1))
+    let disk = (origin: Position.zero, radius: Int32(2))
     
-    let refNodes = [
-      tree.rootNode.children!.bottomRight,
-      tree.rootNode.children!.topLeft,
-      tree.rootNode.children!.topRight,
-      tree.rootNode.children!.bottomLeft.children!.topRight
-    ] + tree.rootNode.children!.bottomRight.children! +
-      tree.rootNode.children!.topLeft.children! +
+    let refNodes = [tree.rootNode.children!.topRight] +
+      [tree.rootNode.children!.bottomRight.children!.topLeft,
+       tree.rootNode.children!.bottomRight.children!.topRight,
+       tree.rootNode.children!.bottomRight.children!.bottomRight] +
+      [tree.rootNode.children!.topLeft.children!.topLeft,
+        tree.rootNode.children!.topLeft.children!.topRight,
+       tree.rootNode.children!.topLeft.children!.bottomRight] +
       tree.rootNode.children!.topRight.children!
     
     var nodesVisited: [Tree.NodeType] = []

--- a/Tests/DynamicLODTreeTests/DynamicLODTreeTests.swift
+++ b/Tests/DynamicLODTreeTests/DynamicLODTreeTests.swift
@@ -473,6 +473,37 @@ class DynamicLODTreeTests: XCTestCase {
       node = n.nextIntersecting(disk)
     }
   }
+  
+  func testIfNextIntersectingVisitsAllIntersectingNodes() {
+    let tree = Tree(initialOrigin: Position.zero, initialDepth: 2)
+    tree.rootNode.subdivide()
+    tree.rootNode.children!.forEach { $0.subdivide() }
+    
+    let disk = (origin: Position.zero, radius: Int32(2))
+    
+    let refNodes = tree.rootNode.children!.bottomLeft.children! +
+      [tree.rootNode.children!.bottomRight.children!.bottomLeft,
+       tree.rootNode.children!.topLeft.children!.bottomLeft,
+       tree.rootNode.children!.bottomLeft,
+       tree.rootNode.children!.bottomRight,
+       tree.rootNode.children!.topLeft]
+    
+    var nodesVisited: [Tree.NodeType] = []
+    
+    var node: Tree.NodeType? = tree.rootNode.nextIntersecting(disk)
+    while let n = node {
+      nodesVisited.append(n)
+      node = n.nextIntersecting(disk)
+    }
+    
+    // check if all visited nodes are included in refNodes
+    XCTAssertTrue(nodesVisited.allSatisfy { ni in
+      refNodes.contains {
+        nj in
+        ni === nj
+      }
+    })
+    
     // check if all refNodes are included in visitedNodes
     XCTAssertTrue(refNodes.allSatisfy { ni in
       nodesVisited.contains {

--- a/Tests/DynamicLODTreeTests/DynamicLODTreeTests.swift
+++ b/Tests/DynamicLODTreeTests/DynamicLODTreeTests.swift
@@ -431,7 +431,7 @@ class DynamicLODTreeTests: XCTestCase {
        tree.rootNode.children!.bottomRight.children!.topRight,
        tree.rootNode.children!.bottomRight.children!.bottomRight] +
       [tree.rootNode.children!.topLeft.children!.topLeft,
-        tree.rootNode.children!.topLeft.children!.topRight,
+       tree.rootNode.children!.topLeft.children!.topRight,
        tree.rootNode.children!.topLeft.children!.bottomRight] +
       tree.rootNode.children!.topRight.children!
     
@@ -451,6 +451,28 @@ class DynamicLODTreeTests: XCTestCase {
       }
     })
     
+    // check if all refNodes are included in visitedNodes
+    XCTAssertTrue(refNodes.allSatisfy { ni in
+      nodesVisited.contains {
+        nj in
+        ni === nj
+      }
+    })
+  }
+  
+  func testIfNextIntersectingNodesIntersectDisk() {
+    let tree = Tree(initialOrigin: Position.zero, initialDepth: 2)
+    tree.rootNode.subdivide()
+    tree.rootNode.children!.forEach { $0.subdivide() }
+    
+    let disk = (origin: Position.zero, radius: Int32(1))
+    
+    var node: Tree.NodeType? = tree.rootNode.nextIntersecting(disk)
+    while let n = node {
+      XCTAssertTrue(n.intersects(disk))
+      node = n.nextIntersecting(disk)
+    }
+  }
     // check if all refNodes are included in visitedNodes
     XCTAssertTrue(refNodes.allSatisfy { ni in
       nodesVisited.contains {

--- a/Tests/DynamicLODTreeTests/DynamicLODTreeTests.swift
+++ b/Tests/DynamicLODTreeTests/DynamicLODTreeTests.swift
@@ -363,4 +363,17 @@ class DynamicLODTreeTests: XCTestCase {
     XCTAssertTrue(tree.fit(to: circle))
     XCTAssertFalse(tree.nodes.contains(where: { $0.isVolatile }))
   }
+  
+  func testIfGrowToContainCircleDoesReclaimNodes() {
+    let tree = Tree(initialOrigin: Position.zero, initialDepth: 1)
+    let circle = (origin: Position.zero, radius: Int32(1))
+    tree.rootNode.subdivide()
+    tree.rootNode.children!.bottomLeft.prune()
+    
+    XCTAssertTrue(tree.grow(toContainCircle: circle))
+    
+    for node in tree.nodes {
+      XCTAssertFalse(node.isVolatile)
+    }
+  }
 }

--- a/Tests/DynamicLODTreeTests/DynamicLODTreeTests.swift
+++ b/Tests/DynamicLODTreeTests/DynamicLODTreeTests.swift
@@ -364,19 +364,6 @@ class DynamicLODTreeTests: XCTestCase {
     XCTAssertFalse(tree.nodes.contains(where: { $0.isVolatile }))
   }
   
-  func testIfGrowToContainCircleDoesReclaimNodes() {
-    let tree = Tree(initialOrigin: Position.zero, initialDepth: 1)
-    let circle = (origin: Position.zero, radius: Int32(1))
-    tree.rootNode.subdivide()
-    tree.rootNode.children!.bottomLeft.prune()
-    
-    XCTAssertTrue(tree.grow(toContainCircle: circle))
-    
-    for node in tree.nodes {
-      XCTAssertFalse(node.isVolatile)
-    }
-  }
-  
   func testIfNodeIntersectsIntersectingDisk() {
     let tree = Tree(initialOrigin: Position.zero)
     let disk = (origin: Position.zero, radius: Int32(1))

--- a/Tests/DynamicLODTreeTests/DynamicLODTreeTests.swift
+++ b/Tests/DynamicLODTreeTests/DynamicLODTreeTests.swift
@@ -376,4 +376,32 @@ class DynamicLODTreeTests: XCTestCase {
       XCTAssertFalse(node.isVolatile)
     }
   }
+  
+  func testIfNodeIntersectsIntersectingDisk() {
+    let tree = Tree(initialOrigin: Position.zero)
+    let disk = (origin: Position.zero, radius: Int32(1))
+    
+    XCTAssertTrue(tree.rootNode.intersects(disk))
+  }
+  
+  func testIfNodeDoesNotIntersectDisjointDisk() {
+    let tree = Tree(initialOrigin: Position.zero)
+    let disk = (origin: Position(-3, 4), radius: Int32(1))
+    
+    XCTAssertFalse(tree.rootNode.intersects(disk))
+  }
+  
+  func testIfNodeIsNotIncludedInPartiallyOverlappingDisk() {
+    let tree = Tree(initialOrigin: Position.zero)
+    let disk = (origin: Position.zero, radius: Int32(1))
+    
+    XCTAssertFalse(tree.rootNode.isIncluded(in: disk))
+  }
+  
+  func testIfNodeIsIncludedInItsBoundingDisk() {
+    let tree = Tree(initialOrigin: Position.zero, initialDepth: 1)
+    let disk = (origin: Position(1, 1), radius: Int32(2))
+    
+    XCTAssertTrue(tree.rootNode.isIncluded(in: disk))
+  }
 }

--- a/Tests/DynamicLODTreeTests/DynamicLODTreeTests.swift
+++ b/Tests/DynamicLODTreeTests/DynamicLODTreeTests.swift
@@ -404,4 +404,59 @@ class DynamicLODTreeTests: XCTestCase {
     
     XCTAssertTrue(tree.rootNode.isIncluded(in: disk))
   }
+  
+  func testIfNextNotIntersectingNodeDoesNotIntersect() {
+    let tree = Tree(initialOrigin: Position.zero, initialDepth: 2)
+    tree.rootNode.subdivide()
+    tree.rootNode.children!.forEach { $0.subdivide() }
+    
+    let disk = (origin: Position.zero, radius: Int32(1))
+    
+    var node: Tree.NodeType? = tree.rootNode.nextNotIntersecting(disk)
+    while let n = node {
+      XCTAssertFalse(n.intersects(disk))
+      node = n.nextNotIntersecting(disk)
+    }
+  }
+  
+  func testIfNextNotIntersectingVisitsAllNotIntersectingNodes() {
+    let tree = Tree(initialOrigin: Position.zero, initialDepth: 2)
+    tree.rootNode.subdivide()
+    tree.rootNode.children!.forEach { $0.subdivide() }
+    
+    let disk = (origin: Position.zero, radius: Int32(1))
+    
+    let refNodes = [
+      tree.rootNode.children!.bottomRight,
+      tree.rootNode.children!.topLeft,
+      tree.rootNode.children!.topRight,
+      tree.rootNode.children!.bottomLeft.children!.topRight
+    ] + tree.rootNode.children!.bottomRight.children! +
+      tree.rootNode.children!.topLeft.children! +
+      tree.rootNode.children!.topRight.children!
+    
+    var nodesVisited: [Tree.NodeType] = []
+    
+    var node: Tree.NodeType? = tree.rootNode.nextNotIntersecting(disk)
+    while let n = node {
+      nodesVisited.append(n)
+      node = n.nextNotIntersecting(disk)
+    }
+    
+    // check if all visited nodes are included in refNodes
+    XCTAssertTrue(nodesVisited.allSatisfy { ni in
+      refNodes.contains {
+        nj in
+        ni === nj
+      }
+    })
+    
+    // check if all refNodes are included in visitedNodes
+    XCTAssertTrue(refNodes.allSatisfy { ni in
+      nodesVisited.contains {
+        nj in
+        ni === nj
+      }
+    })
+  }
 }

--- a/Tests/DynamicLODTreeTests/DynamicLODTreeTests.swift
+++ b/Tests/DynamicLODTreeTests/DynamicLODTreeTests.swift
@@ -512,4 +512,44 @@ class DynamicLODTreeTests: XCTestCase {
       }
     })
   }
+  
+  func testIfReclaimIntersectingDiskReclaimsAllIntersectingNodes() {
+    let tree = Tree(initialOrigin: Position.zero, initialDepth: 2)
+    tree.rootNode.subdivide()
+    tree.rootNode.children!.forEach { $0.subdivide() }
+    
+    tree.nodes.forEach { $0.prune() }
+    
+    let disk = (origin: Position.zero, radius: Int32(2))
+    
+    let modified = tree.reclaim(intersecting: disk)
+    
+    XCTAssertTrue(modified)
+    
+    var node = tree.rootNode.nextIntersecting(disk)
+    while let n = node {
+      XCTAssertFalse(n.isVolatile)
+      node = n.nextIntersecting(disk)
+    }
+  }
+  
+  func testIfReclaimIntersectingDiskDoesNotReclaimsNonIntersectingNode() {
+    let tree = Tree(initialOrigin: Position.zero, initialDepth: 2)
+    tree.rootNode.subdivide()
+    tree.rootNode.children!.forEach { $0.subdivide() }
+    
+    tree.nodes.forEach { $0.prune() }
+    
+    let disk = (origin: Position.zero, radius: Int32(2))
+    
+    let modified = tree.reclaim(intersecting: disk)
+    
+    XCTAssertTrue(modified)
+    
+    var node = tree.rootNode.nextNotIntersecting(disk)
+    while let n = node {
+      XCTAssertTrue(n.isVolatile)
+      node = n.nextNotIntersecting(disk)
+    }
+  }
 }


### PR DESCRIPTION
This PR should fix issue #2.
Currently, it only contains the test case to reproduce the issue.

[grow(toContain circle:) does not reclaim volatile nodes inside the circle](https://app.gitkraken.com/glo/board/5dcf2721e702e8000faecf9b/card/5dd6f7fef01b3f000f153f47)

[Fix #2](https://app.gitkraken.com/glo/board/Xc8nIecC6AAPrs_b/card/XdhYrFfJ0wAPwgTa)
[grow(toContain circle:) does not reclaim volatile nodes inside the circle](https://app.gitkraken.com/glo/board/Xc8nIecC6AAPrs_b/card/Xdb3-vAbPwAPFT9H)